### PR TITLE
Validate url query param to prevent xss

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -117,6 +117,17 @@ const App = () => {
   useEffect(() => {
     const windowUrl = new URL(window.location);
     const url = windowUrl.searchParams.get("url");
+    
+    // Validate URL query parameter actually legitimate to prevent XSS
+    try {
+      const parsedURL = new URL(url);
+      if (parsedURL.protocol !== "http:" && parsedURL.protocol !== "https:")  {
+        send("NO_URL");
+      }
+    } catch (_) {
+      send("NO_URL");  
+    }
+    
     const lsUrl = get("url");
     if (url) {
       setUrl(url);

--- a/worker/workers-site/index.js
+++ b/worker/workers-site/index.js
@@ -169,7 +169,7 @@ const handleCallback = async (event) => {
 
   const headers = {
     Location: url.origin + `?authed=true`,
-    "Set-cookie": `${cookieKey}=${jsonKey.kid}; Max-Age=3600; Secure; SameSite=Lax;`,
+    "Set-cookie": `${cookieKey}=${jsonKey.kid}; Max-Age=3600; Secure; HttpOnly; SameSite=Lax;`,
   };
 
   return new Response(null, {


### PR DESCRIPTION
We had a bug bounty report come in about using the url query parameter to perform XSS. This change validates the URL query parameter is a real URL and starts with http:// or https:// to prevent such attacks. Feel free to make any changes to make this prettier - also not sure if `send("NO_URL")` is the right error condition.