### PR TITLE
fix: allow dash in deploy github url

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -150,7 +150,7 @@ const App = () => {
   }, [send, edgeState]);
 
   const fork = async ({ accountId, apiToken, event }) => {
-    const regex = /github.com\/(?<owner>\w*)\/(?<repo>.*)/;
+    const regex = /github.com\/(?<owner>[^\/]+)\/(?<repo>[^\/]+)/;
     let urlToMatch = url;
     if (urlToMatch.endsWith("/")) urlToMatch = urlToMatch.slice(0, -1);
 


### PR DESCRIPTION
👋  There is an error affecting forking repositories that are having a dash in the "group" URL (github.com/some-name/repository). This PR is fixing the PR to allow such names.

- fixing https://github.com/cloudflare/workers.cloudflare.com/issues/132
- fixing https://github.com/francis-du/url-shortener/issues/15