### PR TITLE
fix: fallback cookieHeader to empty string

### DIFF
--- a/worker/workers-site/index.js
+++ b/worker/workers-site/index.js
@@ -92,7 +92,7 @@ const validateCookie = async (event) => {
   try {
     const { request } = event;
     const cookieHeader =
-      request.headers.get("Cookie") || request.headers.get("Set-cookie");
+      request.headers.get("Cookie") || request.headers.get("Set-cookie") || ""; // cookie.parse accepts string only, undefined throws error
     const cookies = cookie.parse(cookieHeader);
     const auth = cookies[cookieKey];
 


### PR DESCRIPTION
fixes "TypeError: argument str must be a string"