### PR TITLE
fix secrets upload

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -20,16 +20,16 @@ deploy:
       uses: cloudflare/wrangler-action@1.2.0
 ```
 
-2. Add support for `CF_API_TOKEN` and `CF_ACCOUNT_ID` in your workflow:
+2. Add support for `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in your workflow:
 
 ```yaml
 # Update "Publish" step from last code snippet
 - name: Publish
   uses: cloudflare/wrangler-action@1.2.0
   with:
-    apiToken: ${{ secrets.CF_API_TOKEN }}
+    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
   env:
-    CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 ```
 
 3. Add the Markdown code for your button to your project's README, replacing the example `url` parameter with your repository URL.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@cloudflare/pages-plugin-sentry": "^1.0.0",
 				"cookie": "^0.4.0",
+				"rfc4648": "^1.5.2",
 				"tweetsodium": "^0.0.5"
 			},
 			"devDependencies": {
@@ -20246,6 +20247,11 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/rfc4648": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.2.tgz",
+			"integrity": "sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg=="
 		},
 		"node_modules/rgb-regex": {
 			"version": "1.0.1",
@@ -41587,6 +41593,11 @@
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true
+		},
+		"rfc4648": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.2.tgz",
+			"integrity": "sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg=="
 		},
 		"rgb-regex": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"dependencies": {
 		"@cloudflare/pages-plugin-sentry": "^1.0.0",
 		"cookie": "^0.4.0",
+		"rfc4648": "^1.5.2",
 		"tweetsodium": "^0.0.5"
 	},
 	"scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -190,7 +190,7 @@ const App = () => {
 		await fetch(`/secret`, {
 			body: JSON.stringify({
 				repo: repo.full_name,
-				secret_key: 'CF_ACCOUNT_ID',
+				secret_key: 'CLOUDFLARE_ACCOUNT_ID',
 				secret_value: accountId,
 			}),
 			method: 'POST',
@@ -205,7 +205,7 @@ const App = () => {
 		await fetch(`/secret`, {
 			body: JSON.stringify({
 				repo: repo.full_name,
-				secret_key: 'CF_API_TOKEN',
+				secret_key: 'CLOUDFLARE_API_TOKEN',
 				secret_value: apiToken,
 			}),
 			method: 'POST',


### PR DESCRIPTION
- Secrets upload were broken
- Updated deprecated `CF_` prefix to `CLOUDFLARE_`, this is a breaking change. We could create both `CF_` and `CLOUDFLARE_` secrets if we are worried about backwards compatibility, wdyt?

note: we did not switch the domain to pages.dev deployment yet, so nothing was broken in prod