### PR TITLE
Enforce github.com repo URLs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -147,9 +147,10 @@ const App = () => {
 		const url = windowUrl.searchParams.get('url');
 
 		// Validate URL query parameter actually legitimate to prevent XSS
+		// Also validate that hostname is github.com to prevent loading from other URLs
 		try {
 			const parsedURL = new URL(url);
-			if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:') {
+			if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:' || parsedUrl.hostname !== 'github.com') {
 				send('NO_URL');
 			}
 		} catch (_) {


### PR DESCRIPTION
Fixes an issue where arbitrary URLs can be loaded - we should mandate github.com